### PR TITLE
Implement Size::from_str()

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ fn main() {
 }
 ```
 
+## Parsing and formatting
+
+The `size` crate supports parsing textual representations of file sizes into strongly typed `Size` objects, both via the `Size::from_str()` function and its `FromStr` implementation that lets you call `"1234 kilobytes".parse()`.
+
+The `Size` type implements `std::fmt::Display` (in addition to many other traits), which provides a facility to generate properly formatted textual representations of file sizes via the `Size::to_string()` impl of the `ToString` trait or when used in a `format!(..., Size)` context.
+
+By default, `Size` objects are formatted as base-2 (KiB, MiB, etc) with heuristically chosen precision and units. The member function `Size::format()` can be used to override the unit base (e.g. MB vs MiB) and whether or not abbreviated unit names are used (e.g. KiB vs Kebibyte).
+
+Feel free to open a GitHub issue or PR if you need further control over formatting (precision, case, etc)!
+
 ## `no_std` usage
 
 Add the crate to `Cargo.toml` with `default-features` disabled for `no_std` support:

--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ released to the general public under the terms of the MIT public license.
 
 ## To-Do
 
-* Providing a `FromStr` impl to parse file sizes ([coming
-  soon!](https://github.com/neosmart/prettysize-rs/pull/3))
+*This section is currently empty 🎉*
 
 Pull requests are welcome!

--- a/src/from_str.rs
+++ b/src/from_str.rs
@@ -1,0 +1,160 @@
+use std::error::Error;
+use std::str::FromStr;
+
+use crate::consts::*;
+use crate::Size;
+
+/// Represents an error parsing a `Size` from a string representation.
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct ParseSizeError;
+
+impl Error for ParseSizeError {}
+impl core::fmt::Display for ParseSizeError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Error parsing Size")
+    }
+}
+
+impl Size {
+    /// Parse a string representation of size to a `Size` value.
+    ///
+    /// Supports any mix-and-match of the following text formats:
+    /// * 1234
+    /// * 1234 b/kb/mb/etc
+    /// * 1234 B/KB/MB/etc
+    /// * 1234 B/KiB/MiB/etc
+    /// * 1234MB
+    /// * 12.34 GB
+    /// * 1234 byte/kilobyte/terabyte/etc
+    /// * 1234 bytes/kilobytes/terabytes/etc
+    /// * 12.34 Kibibytes/MegaBytes/etc
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use size::Size;
+    ///
+    /// let size = Size::from_str("12.34 KB").unwrap();
+    /// assert_eq!(size.bytes(), 12_340);
+    /// ```
+    pub fn from_str(s: &str) -> Result<Size, crate::ParseSizeError> {
+        FromStr::from_str(s)
+    }
+}
+
+/// This test just ensures everything is wired up correctly between the member function
+/// `[Size::from_str()]` and the `FromStr` trait impl.
+#[test]
+fn from_str() {
+    let input = "12.34 kIloByte";
+    let parsed = Size::from_str(input);
+    let expected = Size::from_bytes(12.34 * crate::consts::KB as f64);
+    assert_eq!(parsed, Ok(expected));
+}
+
+#[test]
+fn parse() {
+    let size = "12.34 kIloByte".parse();
+    assert_eq!(size, Ok(Size::from_bytes(12 * KB + 340)));
+}
+
+impl FromStr for Size {
+    type Err = ParseSizeError;
+
+    fn from_str(s: &str) -> Result<Size, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(ParseSizeError);
+        }
+
+        let (number_str, unit) = match s.split_once(' ') {
+            None => {
+                // Possibly in the format 2mib (no separating space)
+                // Try to split at the first non-numeric value.
+                match s.find(|c: char| !c.is_ascii_digit() && c != '.') {
+                    None => (s, ""), // just a number, no unit
+                    Some(idx) => s.split_at(dbg!(idx)),
+                }
+            }
+            Some((num, unit)) => (num, unit),
+        };
+        let number: f64 = number_str.parse().map_err(|_| ParseSizeError)?;
+
+        let unit = unit.trim().to_lowercase();
+        let multiplier = match unit.as_str().trim_end_matches('s') {
+            "" | "b" | "byte" => B,
+            "kb" | "kilobyte" => KB,
+            "mb" | "megabyte" => MB,
+            "gb" | "gigabyte" => GB,
+            "tb" | "terabyte" => TB,
+            "pb" | "petabyte" => PB,
+            "eb" | "exabyte" => EB,
+
+            "kib" | "kibibyte" => KiB,
+            "mib" | "mebibyte" => MiB,
+            "gib" | "gibibyte" => GiB,
+            "tib" | "tebibyte" => TiB,
+            "pib" | "pebibyte" => PiB,
+            "eib" | "exbibyte" => EiB,
+
+            _ => return Err(ParseSizeError),
+        };
+
+        Ok(Size::from_bytes(number * multiplier as f64))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bare_bytes() {
+        assert_eq!(Size::from_str("1234"), Ok(Size { bytes: 1234 }));
+        assert_eq!(Size::from_str(" 1234 "), Ok(Size { bytes: 1234 })); // Leading and trailing whitespace
+    }
+
+    #[test]
+    fn parse_abbr_unit() {
+        let tests = vec![
+            ("1234B", 1234),
+            ("1234 KB", 1234 * KB),
+            ("1234KiB", 1234 * KiB),
+            ("12.34 MB", (12.34 * MB as f64) as i64),
+            ("12.34MiB", (12.34 * MiB as f64) as i64),
+            (" 1234 GB ", 1234 * GB),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(Size::from_str(input), Ok(Size { bytes: expected }));
+        }
+    }
+
+    #[test]
+    fn parse_full_unit() {
+        let tests = vec![
+            ("1234 bytes", 1234),
+            ("1234 kilobytes", 1234 * KB),
+            ("1234 kibibytes", 1234 * KiB),
+            ("12.34 gigabytes", (12.34 * GB as f64) as i64),
+            ("12.34   gibibytes", (12.34 * GiB as f64) as i64),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(Size::from_str(input), Ok(Size { bytes: expected }));
+        }
+    }
+
+    #[test]
+    fn parse_invalid_inputs() {
+        let tests = vec![
+            "Not a number",
+            "1234 XB",   // Unknown suffix
+            "12..34 MB", // Invalid number format
+        ];
+
+        for input in tests {
+            assert_eq!(dbg!(Size::from_str(input)), Err(ParseSizeError));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,13 @@
 //!
 //! See the documentation of the [`ops`] module for more on this topic.
 //!
+//! ## Parsing sizes from text
+//!
+//! The [`Size::from_str()`] function can be used to convert the most commonly encountered textual
+//! representations of file sizes into properly typed `Size` objects, with flexible support for
+//! various input whitespace formatting, abbreviated/full unit names, mixed upper/lower-case
+//! representation, etc.
+//!
 //! ## Crate features
 //!
 //! This crate currently has one feature (`std`), enabled by default. If compiled with

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,8 @@
 
 #[cfg(feature = "std")]
 pub mod fmt;
+#[cfg(feature = "std")]
+mod from_str;
 pub mod ops;
 #[cfg(feature = "serde")]
 mod serde;
@@ -167,6 +169,8 @@ mod tests_nostd;
 use crate::consts::*;
 #[cfg(feature = "std")]
 pub use crate::fmt::{Base, SizeFormatter, Style};
+#[cfg(feature = "std")]
+pub use crate::from_str::ParseSizeError;
 use crate::sealed::AsIntermediate;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Provides an implementation of from_str() without taking any dependencies. 