### PR TITLE
Allow using fmt::Display without std

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ what this crate can do and how to use it.
 * definitions for the base-two and base-ten file size units defined as `pub const` in the
   `size::consts` namespace, available both in abbreviated and unabridged forms (i.e.
   `consts::KiB` and `consts::KIBIBYTE` or `consts::GB` and `consts::GIGABYTE`),
-* an `std::Display` impl for `Size` to automatically display sizes in a human-readable
+* an `fmt::Display` impl for `Size` to automatically display sizes in a human-readable
   format, automatically choosing the best size unit and numeric precision to
   give the nicest results (you can also use `Size::to_string()` instead).
 * a `Size.format()` method that gives you more control over how sizes are converted
@@ -100,7 +100,7 @@ fn main() {
 
 The `size` crate supports parsing textual representations of file sizes into strongly typed `Size` objects, both via the `Size::from_str()` function and its `FromStr` implementation that lets you call `"1234 kilobytes".parse()`.
 
-The `Size` type implements `std::fmt::Display` (in addition to many other traits), which provides a facility to generate properly formatted textual representations of file sizes via the `Size::to_string()` impl of the `ToString` trait or when used in a `format!(..., Size)` context.
+The `Size` type implements `fmt::Display` (in addition to many other traits), which provides a facility to generate properly formatted textual representations of file sizes via the `Size::to_string()` impl of the `ToString` trait or when used in a `format!(..., Size)` context.
 
 By default, `Size` objects are formatted as base-2 (KiB, MiB, etc) with heuristically chosen precision and units. The member function `Size::format()` can be used to override the unit base (e.g. MB vs MiB) and whether or not abbreviated unit names are used (e.g. KiB vs Kebibyte).
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -373,7 +373,7 @@ impl Size {
     /// It is not necessary to call `.to_string()` if you are passing the formatted size to a
     /// `format!()` macro or similar (e.g. `println!` and friends), as the result implements
     /// [`Display`](core::fmt::Display) and will resolve to the same text.
-    pub fn format(&self) -> FormattableSize {
+    pub fn format(&self) -> FormattableSize<'_> {
         FormattableSize {
             size: self,
             base: DEFAULT_BASE,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@
 //!
 //! The majority of users will be interested in this crate for its ability to "pretty print" sizes
 //! with little ceremony and great results. All `Size` instances implement both
-//! [`std::fmt::Display`] and [`std::fmt::Debug`], so you can just directly `format!(...)` or
+//! [`core::fmt::Display`] and [`core::fmt::Debug`], so you can just directly `format!(...)` or
 //! `println!(...)` with whatever `Size` you have on hand:
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 #![cfg_attr(feature = "std", doc = "```")]
@@ -141,7 +141,6 @@
 //! mode, the following restrictions and limitations are observed:
 //!
 //! * All formatting/stringification of `Size` types is disabled.
-//! * `Size` no longer implements [`std::fmt::Display`] (`core::fmt::Debug` is still implemented).
 //! * The intermediate type used for mathematical operations on `Size` types is changed from `f64`
 //! to `i64` so that no implicit floating-point math is performed. To prevent inadvertent loss of
 //! precision, it is forbidden to pass in floating point values to the `Size` API under `no_std`
@@ -167,7 +166,6 @@
 //! As an example, `struct File { name: String, size: Size } ` will serialize to `{ name: "name",
 //! size: 1234 }` instead of `{ name: "name", size: { bytes: 1234 }`.
 
-#[cfg(feature = "std")]
 pub mod fmt;
 #[cfg(feature = "std")]
 mod from_str;
@@ -180,7 +178,6 @@ mod tests;
 mod tests_nostd;
 
 pub use crate::consts::*;
-#[cfg(feature = "std")]
 pub use crate::fmt::{Base, SizeFormatter, Style};
 #[cfg(feature = "std")]
 pub use crate::from_str::ParseSizeError;
@@ -191,11 +188,8 @@ type Intermediate = f64;
 #[cfg(not(feature = "std"))]
 type Intermediate = i64;
 
-#[cfg(feature = "std")]
 const DEFAULT_BASE: Base = Base::Base2;
-#[cfg(feature = "std")]
 const DEFAULT_STYLE: Style = Style::Default;
-#[cfg(feature = "std")]
 const DEFAULT_SCALE: Option<usize> = None;
 
 mod sealed {


### PR DESCRIPTION
Also fixes the "new" `mismatched_lifetime_syntaxes` warning